### PR TITLE
Fix URL parsing of BONSAI_URL

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,9 +24,8 @@ if RECORD_REQUESTS == True:
 
 if os.environ.get('BONSAI_URL'):
   url = urlparse(os.environ['BONSAI_URL'])
-  bonsai_tuple = url.netloc.partition('@')
-  ELASTICSEARCH_HOST = bonsai_tuple[2]
-  ELASTICSEARCH_AUTH = bonsai_tuple[0]
+  ELASTICSEARCH_HOST = url.hostname
+  ELASTICSEARCH_AUTH = url.username + ':' + url.password
   es = Elasticsearch([{'host': ELASTICSEARCH_HOST}], http_auth=ELASTICSEARCH_AUTH)
 else:
   es = Elasticsearch()

--- a/index_addresses.py
+++ b/index_addresses.py
@@ -6,9 +6,8 @@ from elasticsearch import Elasticsearch
 
 if os.environ.get('BONSAI_URL'):
   url = urlparse(os.environ['BONSAI_URL'])
-  bonsai_tuple = url.netloc.partition('@')
-  ELASTICSEARCH_HOST = bonsai_tuple[2]
-  ELASTICSEARCH_AUTH = bonsai_tuple[0]
+  ELASTICSEARCH_HOST = url.hostname
+  ELASTICSEARCH_AUTH = url.username + ':' + url.password
   es = Elasticsearch([{'host': ELASTICSEARCH_HOST}], http_auth=ELASTICSEARCH_AUTH)
 else:
   es = Elasticsearch()


### PR DESCRIPTION
Addressing comments in #42, this fix uses `urlparse` to parse out the `BONSAI_URL` instead of Python's `partition` method. Minor change.
